### PR TITLE
Update jquery.flexslider.js

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -323,7 +323,7 @@
           startY,
           offset,
           cwidth,
-          dx,
+          dx = null,
           startT,
           scrolling = false;
               
@@ -366,7 +366,7 @@
         }
         
         function onTouchEnd(e) {
-          if (slider.animatingTo === slider.currentSlide && !scrolling && !(dx === null)) {
+          if (slider.animatingTo === slider.currentSlide && !scrolling && dx !== null) {
             var updateDx = (reverse) ? -dx : dx,
                 target = (updateDx > 0) ? slider.getTarget('next') : slider.getTarget('prev');
             


### PR DESCRIPTION
Necessary to preset `dx` to `null`, otherwise when we hit line 369 the wrong path is taken, `slider.animating` is permanently set to true and the slider stops responding.

This problem occurs when touching a slide within a synced carousel, directly after the page has loaded, and before any interactions with the main slider. Thank goodness for remote debugging using Chrome.
